### PR TITLE
Sending emails

### DIFF
--- a/miniproject.py
+++ b/miniproject.py
@@ -15,7 +15,7 @@ from services import view_all as ViewAllService
 from services import manage as ManageService
 from services import stream_service
 
-templates_dir = os.path.normpath(os.path.dirname(__file__) + '/../www/')
+templates_dir = os.path.normpath(os.path.dirname(__file__) + '/www/')
 
 JINJA_ENVIRONMENT = jinja2.Environment(
     loader=jinja2.FileSystemLoader(templates_dir),

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -20,4 +20,4 @@ class CreateStream(webapp2.RequestHandler):
         stream = Stream(name=stream_name, cover_url=stream_cover_url, tags=tags)
         stream_key = stream.put()
 
-        #TODO Send emails!
+        self.response.location = '/view?id={0}'.format(stream_key.id())

--- a/www/layout.html
+++ b/www/layout.html
@@ -43,7 +43,7 @@
               <a class="nav-link" href="manage">Manage</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="create">Create</a>
+              <a class="nav-link" href="create_stream">Create</a>
             </li>
             <li class="nav-item active">
               <a class="nav-link" href="view">View</a>


### PR DESCRIPTION
There a few  changes here.

create_stream is now the responsible to send emails, since creating a stream is only possible from the web interface, as far as I know. 
I'm also fixing the login page and the shared layout.
Most importantly the post method for creating a new stream returns a link to the newly created stream. This provides the necessary information to send the email to the requested subscribers.
I tested this and the sender is the user that is logged in, so we should consider restricting all pages to be only visible if the user is logged in. i.e. no Anonymous users.

