### PR TITLE
Emailing Quota raised - Cron Email bug fixed

### DIFF
--- a/miniproject.py
+++ b/miniproject.py
@@ -45,7 +45,7 @@ class MainPage(webapp2.RequestHandler):
         create_user_url = self.uri_for('api-create-user', _full=True)
         result = urlfetch.fetch(
             url=create_user_url,
-            payload=json.dumps({'user_id': user.user_id()}),
+            payload=json.dumps({'user_id': user.user_id(), 'user_email': user.email()}),
             method=urlfetch.POST,
             headers= {'Content-Type': 'application/json'}
         )

--- a/models/connexus_user.py
+++ b/models/connexus_user.py
@@ -5,6 +5,7 @@ from google.appengine.ext import ndb
 
 class ConnexusUser(ndb.Model):
     user_id = ndb.StringProperty()
+    user_email = ndb.StringProperty()
     report = ndb.IntegerProperty()
     streams_subscribed = ndb.KeyProperty(Stream, repeated=True)
 

--- a/services/create_user.py
+++ b/services/create_user.py
@@ -12,9 +12,10 @@ class CreateUser(webapp2.RequestHandler):
         dict_object = json.loads(json_string)
 
         user_id = dict_object['user_id']
+        user_email = dict_object['user_email']
 
         user_result = ConnexusUser.from_user_id(user_id)
         
         if not user_result: 
-            user = ConnexusUser(user_id=user_id, report=0, streams_subscribed=[])
+            user = ConnexusUser(user_id=user_id, user_email=user_email, report=0, streams_subscribed=[])
             user_key = user.put()

--- a/services/send_user_report.py
+++ b/services/send_user_report.py
@@ -15,7 +15,7 @@ class SendUserReport(webapp2.RequestHandler):
         self.response.headers['Content-Type'] = 'application/json'
         rate = self.request.get('rate')
         report_rate = int(rate)
-        email_address = "rayolanderos@gmail.com"
+        email_address = "noreply@ut-apt-miniproject-greenteam.appspotmail.com"
         email_subject = "This is your requested digest for connexus"
 
         subscribers = ConnexusUser.query(ConnexusUser.report == report_rate).fetch()
@@ -23,7 +23,7 @@ class SendUserReport(webapp2.RequestHandler):
         subs_emails = []
 
         for subscriber in subscribers:
-            subs_emails.append(subscriber.user_id)
+            subs_emails.append(subscriber.user_email)
 
         trending_api_uri = self.uri_for('api-trending', _full=True)
 


### PR DESCRIPTION
Another bug was introduced when switching the user_id from email to ID: The cron jobs relied on that user_id as the recipient. I've added a new field that stores the email so that the cron can access it. 

Sendgrid integration was also failing for me (you can see the sendgrid branch). I ended up raising the Quota on the app by registering the app in the cloud or something like that. We now have 100. Hopefully that's enough. I've deployed and tested and all crons are running and sending emails.  